### PR TITLE
fix: Bump dependencies version to fix issue with xcode 15.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
+        "version" : "1.0.0"
       }
     },
     {
@@ -14,8 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -23,8 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "7a094fcc6a4fcb34fbe625ecd3acd81b881a6dfb",
-        "version" : "0.1.3"
+        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     },
     {
@@ -32,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a9daebf0bf65981fd159c885d504481a65a75f02",
-        "version" : "0.8.0"
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/pointfreeco/xctest-dynamic-overlay",
-            from: "0.8.0"),
+            from: "1.0.0"),
         .package(
             url: "https://github.com/pointfreeco/swift-dependencies",
-            from: "0.1.0"
+            from: "1.0.0"
         ),
     ],
     targets: [


### PR DESCRIPTION
The point-free dependencies all rely on the `swift-custom-dump` dependency which doesn't work on Xcode 15.3.
More info in this [discussion](https://github.com/pointfreeco/swift-custom-dump/discussions/114).

In order to fix it, it's required to bump the version to '1.2.1' which requires all point-free dependencies to be > 1.0.0.

The dependencies of GLS ( > 1.0.0, < 2.0.0) were conflicting with the dependencies here (< 1.0.0).